### PR TITLE
Remove pathes with empty coordinates when saving dashboard

### DIFF
--- a/cbpi4gui/src/components/dashboard/DashboardContext.js
+++ b/cbpi4gui/src/components/dashboard/DashboardContext.js
@@ -253,7 +253,14 @@ export const DashboardProvider = ({ children }) => {
 
   const save = (DashboardID = 1) => {
     let e = elements2.map((value) => ({ id: value.id, name: value.name, x: value.x, y: value.y, type: value.type, props: { ...value.props } }));
-    let p = pathes.map((value) => ({ id: value.id, coordinates: value.coordinates, condition: value.condition }));
+    // let p = pathes.map((value) => ({ id: value.id, coordinates: value.coordinates, condition: value.condition }));
+    var p = [];
+    pathes.forEach(function(value) {  // remove pathes with empty coordinates
+        if (value.coordinates.length != 0) {
+            var newValue = {id: value.id, coordinates: value.coordinates, condition: value.condition };
+            p.push(newValue);
+        }
+    });
     //console.log("DEBUG CONDITION SAVED")
     //console.log(p);
     dashboardapi.save(DashboardID, { elements: e, pathes: p }, () => {


### PR DESCRIPTION
![dashboard_pathes_with_empty_coordinates](https://user-images.githubusercontent.com/61159697/210758984-38da3bcb-a68e-4020-b4d5-5ef859310d75.png)

This happens, when pathes are removed by double-clicking on path endpoints.